### PR TITLE
Add old value to operation when rationalization is enabled

### DIFF
--- a/differ.go
+++ b/differ.go
@@ -197,6 +197,7 @@ func (d *Differ) rationalize(ptr pointer, src, tgt interface{}, lastOpIdx int, d
 	replaceOp := Operation{
 		Type:     OperationReplace,
 		Path:     ptr.string(), // shallow copy
+		OldValue: src,
 		Value:    tgt,
 		valueLen: len(doc),
 	}

--- a/differ.go
+++ b/differ.go
@@ -25,14 +25,15 @@ type (
 )
 
 type options struct {
-	ignores     map[string]struct{}
-	marshal     marshalFunc
-	unmarshal   unmarshalFunc
-	hasIgnore   bool
-	factorize   bool
-	rationalize bool
-	invertible  bool
-	equivalent  bool
+	ignores          map[string]struct{}
+	marshal          marshalFunc
+	unmarshal        unmarshalFunc
+	hasIgnore        bool
+	factorize        bool
+	rationalize      bool
+	invertible       bool
+	equivalent       bool
+	rationalizeArray bool
 }
 
 type jsonNode struct {


### PR DESCRIPTION
We also need to show the old value when rationalization is enabled. 
It's helpful in some sense in detail to compare.