### PR TITLE
Add oldValue to operation when the rationalize is enabled

### DIFF
--- a/differ.go
+++ b/differ.go
@@ -197,6 +197,7 @@ func (d *Differ) rationalize(ptr pointer, src, tgt interface{}, lastOpIdx int, d
 	replaceOp := Operation{
 		Type:     OperationReplace,
 		Path:     ptr.string(), // shallow copy
+		OldValue: src,
 		Value:    tgt,
 		valueLen: len(doc),
 	}


### PR DESCRIPTION
We also need to show the old value when rationalization is enabled.
It's helpful in some sense in detail to compare.