### PR TITLE
fix bounds error when diffing pathologically different large files

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -127,6 +127,9 @@ func (p *Patch) prepend(startIdx int, typ string, from, path string, src, tgt in
 		Value:    tgt,
 		valueLen: vl,
 	}
+	if startIdx > len(*p) {
+		*p = append(*p, Operation{})
+	}
 	return append((*p)[:startIdx], append([]Operation{op}, (*p)[startIdx:]...)...)
 }
 


### PR DESCRIPTION
When doing `LCS` diffs of very large and very different files we would keep seeing crashes when calling the `prepend` function.  Adding this (dumb) check fixes it, it appears that when `startIdx` is at the end of the array, the array isn't _yet_ large enough to accommodate this operation.